### PR TITLE
Add optimistic rollups

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -224,6 +224,17 @@ export const images = [
     }, 
   },
   {
+    name: "optimistic-rollups",
+    id: "optimistic-rollups",
+    category: ["all", "ethereum", "layer 2"],
+    url: "https://ik.imagekit.io/rekahbeee/optimistic-rollups.svg?updatedAt=1734688820473",
+    author: {
+      name: "Rebekah",
+      url: "https://github.com/rekahbeee",
+      image: "https://github.com/rekahbeee.png",
+    }, 
+  },
+  {
   "name": "Suilend",
   "id": "suilend",
   "category": ["all", "defi"],


### PR DESCRIPTION
Add optimistic rollups using Arbitrum as example:
![optimistic-rollups](https://github.com/user-attachments/assets/2850f050-54ef-47ac-a201-7c866f101057)
